### PR TITLE
make get icon regex match in other folders

### DIFF
--- a/index.js
+++ b/index.js
@@ -289,7 +289,7 @@ exports.decorateConfig = (config) => {
 
 // Current process icon
 const getIcon = (title) => {
-    const process = title.match(/(?:[\s]+|^)(gulp|php|node|npm|yarn|vim|nvim|python|mysql)(?:[\s]+|$)/i);
+    const process = title.match(/(?:[\s]+|\s*(?:\/\w){0,}|^)(gulp|php|node|npm|yarn|vim|nvim|python|mysql)(?:[\s]+|$)/i);
     return process ? process[0].trim().toLowerCase() : 'shell';
 };
 


### PR DESCRIPTION
my vim is working from /usr/local/bin/ so the process name seems as /usr/local/bin/vim. i updated the regex matches in other folders.