### PR TITLE
Add support for version numbered commands

### DIFF
--- a/index.js
+++ b/index.js
@@ -303,7 +303,7 @@ exports.decorateConfig = (config) => {
 
 // Current process icon
 const getIcon = (title) => {
-    const process = title.match(/(?:[\s]+|^)(gulp|php|node|npm|yarn|vim|nvim|python|mysql)(?:[\s]+|$)/i);
+    const process = title.match(/(?:[\s]+|^)(gulp|php|node|npm|yarn|vim|nvim|python|mysql)(?:[\s]+|\d+$)/i);
     return process ? process[0].trim().toLowerCase() : 'shell';
 };
 


### PR DESCRIPTION
Add regex support for commands which include a version number. 
i.e `python3 main.py` or `php7` which previously were not recognised.